### PR TITLE
Use model-specified soft delete column name

### DIFF
--- a/src/Observers/DeepSync.php
+++ b/src/Observers/DeepSync.php
@@ -143,7 +143,8 @@ class DeepSync implements ShouldHandleEventsAfterCommit
     private function handleDelete(Collection $parents, Model $childRecord): void
     {
         $parents->filter(function($parent) {
-            return $parent->deleted_at === null;
+            $deletedAtColumn = $parent->getDeletedAtColumn();
+            return $parent->$deletedAtColumn === null;
         });
 
         if (!count($parents)) {

--- a/tests/Database/migrations/2024_09_27_160051_create_posts_table.php
+++ b/tests/Database/migrations/2024_09_27_160051_create_posts_table.php
@@ -18,7 +18,7 @@ return new class extends Migration
             $table->string('title');
             $table->text('body');
             $table->timestamps();
-            $table->softDeletes();
+            $table->timestamp('archive_date')->nullable();
         });
     }
 

--- a/tests/Models/Post.php
+++ b/tests/Models/Post.php
@@ -27,6 +27,8 @@ class Post extends Model
         'is_active'
     ];
 
+    const DELETED_AT = 'archive_date';
+
     /**
      * DeepSync properties and trigger values
      */


### PR DESCRIPTION
Allows for model-defined soft delete column names when using the Laravel-supported `DELETED_AT` const.

Fixes #1 